### PR TITLE
dyndns-server: Follow the Filesystem Hierarchy Standard of Linux.

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -2,7 +2,7 @@ FROM node:10.11.0-alpine
 
 RUN apk add --no-cache git python build-base bind-tools bash
 
-WORKDIR /usr/src/app
+WORKDIR /opt/app
 
 ADD src .
 


### PR DESCRIPTION
The current data path is installed under /usr/src, a directory reserved
for linux kernel sources. Follow the Filesystem Hierarchy Standard
of Linux, and use /opt/ instead.

Refs: https://github.com/dappnode/DAppNode/issues/39