### PR TITLE
Feature/remote updating

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ In most of the cases, nodes running at home are using a dynamic IP provided by t
 
 Configure variables in docker-compose.yml to fit your needs.
 
+Bind server can be updated remotely with a key using RFC 2136 standard. Feature is enabled by specifing `KEY_NAME` and `KEY_PATH` envirnoment variables. Keyfile can be generated with `tsig-keygen -a hmac-sha512 $KEY_NAME > $KEY_PATH`.
+
 Then the services can be deployed using docker compose:
 
 ```

--- a/bind/Dockerfile
+++ b/bind/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine
 
 RUN apk --no-cache add bash bind gettext && \
-    mkdir -p /var/bind/log
+    mkdir -p /var/bind/log && mkdir -p /etc/certbot
 
 COPY templates /etc/bind/templates
 COPY init.sh .

--- a/bind/init.sh
+++ b/bind/init.sh
@@ -5,8 +5,8 @@ export UPDATE_HOST=${UPDATE_HOST:-127.0.0.1}
 export RECORD_TTL=${RECORD_TTL:-30}
 export DLR='$'
 
-export KEY_PATH=${KEY_PATH:-"/etc/bind/.secrets/certbot.key"}
-export KEY_NAME=${KEY_NAME:-"certbot"}
+export KEY_PATH=${KEY_PATH:-"/etc/bind/.secrets/keyfile.key"}
+export KEY_NAME=${KEY_NAME:-"keyname"}
 
 # Do not overwrite existing zone file
 if [ ! -f "/etc/bind/$ZONE.zone" ]; then

--- a/bind/init.sh
+++ b/bind/init.sh
@@ -5,6 +5,9 @@ export UPDATE_HOST=${UPDATE_HOST:-127.0.0.1}
 export RECORD_TTL=${RECORD_TTL:-30}
 export DLR='$'
 
+export KEY_PATH=${KEY_PATH:-"/etc/bind/.secrets/certbot.key"}
+export KEY_NAME=${KEY_NAME:-"certbot"}
+
 # Do not overwrite existing zone file
 if [ ! -f "/etc/bind/$ZONE.zone" ]; then
     envsubst <"/etc/bind/templates/template.zone" >"/etc/bind/$ZONE.zone"

--- a/bind/init.sh
+++ b/bind/init.sh
@@ -7,10 +7,10 @@ export DLR='$'
 
 if [ -z $KEY_PATH ]; then
     export INCLUDE_LINE=""
-    export UPDATE_LINE="allow-update { ${UPDATE_HOST}; };"
+    export UPDATE_LINE="${UPDATE_HOST};"
 else
     export INCLUDE_LINE="include \"$KEY_PATH\";"
-    export UPDATE_LINE="allow-update {key \"${KEY_NAME}\"; ${UPDATE_HOST}; };"
+    export UPDATE_LINE="key \"${KEY_NAME}\"; ${UPDATE_HOST};"
 fi
 
 # Do not overwrite existing zone file

--- a/bind/init.sh
+++ b/bind/init.sh
@@ -5,7 +5,7 @@ export UPDATE_HOST=${UPDATE_HOST:-127.0.0.1}
 export RECORD_TTL=${RECORD_TTL:-30}
 export DLR='$'
 
-export KEY_PATH=${KEY_PATH:-"/etc/bind/.secrets/keyfile.key"}
+export KEY_PATH=${KEY_PATH:-"/etc/certbot/keyfile.key"}
 export KEY_NAME=${KEY_NAME:-"keyname"}
 
 # Do not overwrite existing zone file

--- a/bind/init.sh
+++ b/bind/init.sh
@@ -5,8 +5,13 @@ export UPDATE_HOST=${UPDATE_HOST:-127.0.0.1}
 export RECORD_TTL=${RECORD_TTL:-30}
 export DLR='$'
 
-export KEY_PATH=${KEY_PATH:-"/etc/certbot/keyfile.key"}
-export KEY_NAME=${KEY_NAME:-"keyname"}
+if [ -z $KEY_PATH ]; then
+    export INCLUDE_LINE=""
+    export UPDATE_LINE="allow-update { ${UPDATE_HOST}; };"
+else
+    export INCLUDE_LINE="include \"$KEY_PATH\";"
+    export UPDATE_LINE="allow-update {key \"${KEY_NAME}\"; ${UPDATE_HOST}; };"
+fi
 
 # Do not overwrite existing zone file
 if [ ! -f "/etc/bind/$ZONE.zone" ]; then

--- a/bind/templates/named.conf
+++ b/bind/templates/named.conf
@@ -26,5 +26,5 @@ zone "${ZONE}" {
 	file "/etc/bind/${ZONE}.zone";
 	allow-query { any; };
 	allow-transfer { none; };
-  ${UPDATE_LINE}
+  allow-update {${UPDATE_LINE}};
 };

--- a/bind/templates/named.conf
+++ b/bind/templates/named.conf
@@ -19,12 +19,12 @@ options {
         listen-on-v6 { any; };
 };
 
-include "${KEY_PATH}";
+${INCLUDE_LINE}
 
 zone "${ZONE}" {
 	type master;
 	file "/etc/bind/${ZONE}.zone";
 	allow-query { any; };
 	allow-transfer { none; };
-	allow-update { key "${KEY_NAME}"; ${UPDATE_HOST}; };
+  ${UPDATE_LINE}
 };

--- a/bind/templates/named.conf
+++ b/bind/templates/named.conf
@@ -19,12 +19,12 @@ options {
         listen-on-v6 { any; };
 };
 
-include ${KEY_PATH};
+include "${KEY_PATH}";
 
 zone "${ZONE}" {
 	type master;
 	file "/etc/bind/${ZONE}.zone";
 	allow-query { any; };
 	allow-transfer { none; };
-	allow-update { key ${KEY_YNAME}; ${UPDATE_HOST}; };
+	allow-update { key "${KEY_NAME}"; ${UPDATE_HOST}; };
 };

--- a/bind/templates/named.conf
+++ b/bind/templates/named.conf
@@ -19,10 +19,12 @@ options {
         listen-on-v6 { any; };
 };
 
+include ${KEY_PATH};
+
 zone "${ZONE}" {
 	type master;
 	file "/etc/bind/${ZONE}.zone";
 	allow-query { any; };
 	allow-transfer { none; };
-	allow-update { ${UPDATE_HOST}; };
+	allow-update { key ${KEY_YNAME}; ${UPDATE_HOST}; };
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - ZONE=dyndns.dappnode.io
       - UPDATE_HOST=172.18.0.0/16
       - KEY_NAME=certbot
-      - KEY_PATH="/etc/certbot/certbot.key"
+      - KEY_PATH=/etc/certbot/certbot.key
     restart: always
 
   dyndns-api:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,12 @@ services:
       - "53:53/udp"
     volumes:
       - "bind-config:/etc/bind/"
+      - "certbot-config:/etc/certbot/"
     environment:
       - ZONE=dyndns.dappnode.io
       - UPDATE_HOST=172.18.0.0/16
+      - KEY_NAME=certbot
+      - KEY_PATH="/etc/certbot/certbot.key"
     restart: always
 
   dyndns-api:
@@ -72,6 +75,7 @@ services:
 
 volumes:
   bind-config:
+  certbot-config:
   nginx-config:
   nginx-certs:
   nginx-vhosts:


### PR DESCRIPTION
Added bind updating via key.

I decided for this option where whole keyfile is hidden inside volume. (We can discuss it further on Tuesday).

From updated docker-compose.yml, you can see new requirements for deploying. In short, I added new volume `certbot-config` which holds secret key. New environment variables are: 
- KEY_PATH points to a file inside certbot-config volume. That file can be generated with `tsig-keygen` command, for example: `tsig-keygen -a hmac-sha512 $keyname > ${keyname}.key`. 
- KEY_NAME should be exactly `$keyname` from previous point

Additionaly, if KEY_PATH is not set, bind should start without key access (so same as before).

Please note that I didn't specify certbot-config volume as external, even though keyfile must be copied to it manually. Whether is it necessary to be external or not depends on your deployment strategy so I left it as is.